### PR TITLE
move prepareForUsage to manager.

### DIFF
--- a/src/Models/SEO.php
+++ b/src/Models/SEO.php
@@ -16,34 +16,4 @@ class SEO extends Model
     {
         return $this->morphTo();
     }
-
-    public function prepareForUsage(): SEOData
-    {
-        if ( method_exists($this->model, 'getDynamicSEOData') ) {
-            $overrides = $this->model->getDynamicSEOData();
-        }
-
-        if ( method_exists($this->model, 'enableTitleSuffix') ) {
-            $enableTitleSuffix = $this->model->enableTitleSuffix();
-        } elseif ( property_exists($this->model, 'enableTitleSuffix') ) {
-            $enableTitleSuffix = $this->model->enableTitleSuffix;
-        }
-
-        return new SEOData(
-            title            : $overrides->title ?? $this->title,
-            description      : $overrides->description ?? $this->description,
-            author           : $overrides->author ?? $this->author,
-            image            : $image ?? ( $overrides->image ?? $this->image ),
-            url              : $overrides->url ?? null,
-            enableTitleSuffix: $enableTitleSuffix ?? true,
-            published_time   : $overrides->published_time ?? ( $this->model?->created_at ?? null ),
-            modified_time    : $overrides->modified_time ?? ( $this->model?->updated_at ?? null ),
-            articleBody      : $overrides->articleBody ?? null,
-            section          : $overrides->section ?? null,
-            tags             : $overrides->tags ?? null,
-            schema           : $overrides->schema ?? null,
-            type             : $overrides->type ?? null,
-            locale           : $overrides->locale ?? null,
-        );
-    }
 }


### PR DESCRIPTION
move prepareForUsage to manager. so it can detect the model getDynamicSEOData when there is no seo object.


use case,
i have models (ex: `Posts`) has no `SEO` related to it

i add `HasSEO` trait and adds the method getDynamicSEOData 

expected: it can dynamically get the seo data

but the results was: No `SEO` model? okay, not seo at all