### PR TITLE
Add canonical_url to SEO Data object for override

### DIFF
--- a/database/migrations/create_seo_table.php.stub
+++ b/database/migrations/create_seo_table.php.stub
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('image')->nullable();
             $table->string('author')->nullable();
             $table->string('robots')->nullable();
+            $table->string('canonical_url')->nullable();
 
             $table->timestamps();
         });

--- a/src/Models/SEO.php
+++ b/src/Models/SEO.php
@@ -45,6 +45,7 @@ class SEO extends Model
             type: $overrides->type ?? null,
             locale: $overrides->locale ?? null,
             robots: $overrides->robots ?? $this->robots,
+            canonical_url: $overrides->canonical_url ?? $this->url,
         );
     }
 }

--- a/src/Models/SEO.php
+++ b/src/Models/SEO.php
@@ -20,6 +20,7 @@ class SEO extends Model
     public function prepareForUsage(): SEOData
     {
         if ( method_exists($this->model, 'getDynamicSEOData') ) {
+            /** @var SEOData $overrides */
             $overrides = $this->model->getDynamicSEOData();
         }
 

--- a/src/Models/SEO.php
+++ b/src/Models/SEO.php
@@ -45,7 +45,7 @@ class SEO extends Model
             type: $overrides->type ?? null,
             locale: $overrides->locale ?? null,
             robots: $overrides->robots ?? $this->robots,
-            canonical_url: $overrides->canonical_url ?? $this->url,
+            canonical_url: $overrides->canonical_url ?? $this->canonical_url,
         );
     }
 }

--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -31,6 +31,7 @@ class SEOData
         public ?string $favicon = null,
         public ?string $locale = null,
         public ?string $robots = null,
+        public ?string $canonical_url = null,
     ) {
         if ( $this->locale === null ) {
             $this->locale = Str::of(app()->getLocale())->lower()->kebab();

--- a/src/Tags/CanonicalTag.php
+++ b/src/Tags/CanonicalTag.php
@@ -17,7 +17,7 @@ class CanonicalTag extends Collection implements Renderable
         $collection = new static();
 
         if ( config('seo.canonical_link') ) {
-            $collection->push(new LinkTag('canonical', $SEOData->url));
+            $collection->push(new LinkTag('canonical', $SEOData->canonical_url ?? $SEOData->url));
         }
 
         return $collection;

--- a/tests/Feature/Tags/CanonicalTagTest.php
+++ b/tests/Feature/Tags/CanonicalTagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
 
@@ -47,4 +49,26 @@ it('can display the model level canonical url if set on override', function () {
 
     get(route('seo.test-page', ['page' => $page]))
         ->assertSee('<link rel="canonical" href="https://example.com/canonical/url/test">', false);
+});
+
+it('will not break if no canonical_url column exists in seo table', function () {
+    // New seo.canonical_url column was added in https://github.com/ralphjsmit/laravel-seo/pull/35.
+    config()->set('seo.canonical_link', true);
+
+    $page = Page::create();
+
+    expect(Schema::hasColumn('seo', 'canonical_url'))
+        ->toBeTrue();
+
+    Schema::table('seo', function (Blueprint $table) {
+        $table->dropColumn('canonical_url');
+    });
+
+    expect(Schema::hasColumn('seo', 'canonical_url'))
+        ->toBeFalse();
+
+    $page->refresh();
+
+    get(route('seo.test-page', ['page' => $page]))
+        ->assertOk();
 });

--- a/tests/Feature/Tags/CanonicalTagTest.php
+++ b/tests/Feature/Tags/CanonicalTagTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Str;
 
+use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
+
 use function Pest\Laravel\get;
 
 it('can display the canonical URL if allowed', function () {
@@ -18,3 +20,17 @@ it('cannot display the canonical url if not allowed', function () {
         ->assertDontSee('rel="canonical"', false);
 });
 
+it('can display the model level canonical url if set', function () {
+    config()->set('seo.canonical_link', true);
+
+    $page = Page::create();
+
+    $page::$overrides = [
+        'canonical_url' => 'https://example.com/canonical/url/test',
+    ];
+
+    $page->refresh();
+
+    get(route('seo.test-page', ['page' => $page]))
+        ->assertSee('<link rel="canonical" href="https://example.com/canonical/url/test">', false);
+});

--- a/tests/Feature/Tags/CanonicalTagTest.php
+++ b/tests/Feature/Tags/CanonicalTagTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-
 use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
 
 use function Pest\Laravel\get;
@@ -20,7 +19,22 @@ it('cannot display the canonical url if not allowed', function () {
         ->assertDontSee('rel="canonical"', false);
 });
 
-it('can display the model level canonical url if set', function () {
+it('can display the model level canonical url if set in database', function () {
+    config()->set('seo.canonical_link', true);
+
+    $page = Page::create();
+
+    $page->seo->update([
+        'canonical_url' => 'https://example.com/canonical/url/test',
+    ]);
+
+    $page->refresh();
+
+    get(route('seo.test-page', ['page' => $page]))
+        ->assertSee('<link rel="canonical" href="https://example.com/canonical/url/test">', false);
+});
+
+it('can display the model level canonical url if set on override', function () {
     config()->set('seo.canonical_link', true);
 
     $page = Page::create();


### PR DESCRIPTION
This PR adds an override to the SEOData object for the `canonical_url` to be set on a model by model basis. 

Resolves https://github.com/ralphjsmit/laravel-seo/issues/33