### PR TITLE
Add support for immutable timestamps

### DIFF
--- a/src/Schema/ArticleSchema.php
+++ b/src/Schema/ArticleSchema.php
@@ -2,7 +2,7 @@
 
 namespace RalphJSmit\Laravel\SEO\Schema;
 
-use Illuminate\Support\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 
@@ -10,9 +10,9 @@ class ArticleSchema extends Schema
 {
     public array $authors = [];
 
-    public ?Carbon $datePublished = null;
+    public ?CarbonInterface $datePublished = null;
 
-    public ?Carbon $dateModified = null;
+    public ?CarbonInterface $dateModified = null;
 
     public ?string $description = null;
 

--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -2,7 +2,7 @@
 
 namespace RalphJSmit\Laravel\SEO\Support;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Str;
 use RalphJSmit\Helpers\Laravel\Pipe\Pipeable;
 use RalphJSmit\Laravel\SEO\SchemaCollection;
@@ -19,8 +19,8 @@ class SEOData
         public ?string $url = null,
         public bool $enableTitleSuffix = true,
         public ?ImageMeta $imageMeta = null,
-        public ?Carbon $published_time = null,
-        public ?Carbon $modified_time = null,
+        public ?CarbonInterface $published_time = null,
+        public ?CarbonInterface $modified_time = null,
         public ?string $articleBody = null,
         public ?string $section = null,
         public ?array $tags = null,

--- a/tests/Unit/Models/SEOTest.php
+++ b/tests/Unit/Models/SEOTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
 use RalphJSmit\Laravel\SEO\Models\SEO;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
@@ -15,6 +17,16 @@ it('can morph a model to the SEO model', function () {
 });
 
 it('can prepare the SEO for use on a page', function () {
+    $seo = Page::create()->seo;
+
+    $export = $seo->prepareForUsage();
+
+    expect($export)->toBeInstanceOf(SEOData::class);
+});
+
+it('can have immutable timestamps', function () {
+    Date::useClass(CarbonImmutable::class);
+
     $seo = Page::create()->seo;
 
     $export = $seo->prepareForUsage();


### PR DESCRIPTION
When Laravel is configured to use `CarbonImmutable` when generating date objects (e.g. Carbon instances for model timestamps), this package fails as `Carbon` is type hinted.

This PR updates the typehint to `CarbonInterface` so that both `Carbon` and `CarbonImmutable` are supported.