### PR TITLE
Correctly render og:locale

### DIFF
--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -34,7 +34,7 @@ class SEOData
         public ?string $canonical_url = null,
     ) {
         if ( $this->locale === null ) {
-            $this->locale = Str::of(app()->getLocale())->lower()->kebab();
+            $this->locale = app()->getLocale();
         }
     }
 

--- a/tests/Feature/Tags/OpenGraphTagsTest.php
+++ b/tests/Feature/Tags/OpenGraphTagsTest.php
@@ -115,3 +115,10 @@ it('can correctly render OpenGraph tags for a post or page with a few additional
         ->assertSee('<meta property="article:tag" content="PHP">', false)
         ->assertSee('<meta property="article:tag" content="Laravel">', false);
 });
+
+it('can correctly render locale tags', function () {
+    config()->set('app.locale', 'en_GB');
+
+    get(route('seo.test-plain'))
+        ->assertSee('<meta property="og:locale" content="en_GB">', false);
+});


### PR DESCRIPTION
Disclaimer: I am not very familiar with the code behind this package, so let me know if I made any mistakes.

----

This PR solves https://github.com/ralphjsmit/laravel-seo/issues/49

Looking at `SEOData` it _seems_ like a few mistakes were made:

- It lowercases the locale, making `nl_NL` render `nl_nl`. Afaik, this is against the opengraph protocol: https://ogp.me/
- It kebab cases the locale. I am not sure why that's done. The locale should be in snake case, not kebab case. I could change it to `snake()` but `app.locale` should be configured in snake case already. If they don't, I think they will have bigger problems than this library not working.