### PR TITLE
feat: Laravel 11.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           - laravel: 10.*
             testbench: ^8.0
           - laravel: 11.*
-            testbench: ^8.0
+            testbench: 9.x-dev
         exclude:
           - php: 8.1
             laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,9 @@ jobs:
             testbench: ^8.0
           - laravel: 11.*
             testbench: ^8.0
+        exclude:
+          - php: 8.1
+            laravel: 11.*
 
     continue-on-error: ${{ matrix.laravel == '9.*' && matrix.stability == 'prefer-lowest' }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           - laravel: 10.*
             testbench: ^8.0
           - laravel: 11.*
-            testbench: 9.x-dev
+            testbench: ^9.0
         exclude:
           - php: 8.1
             laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,8 +27,6 @@ jobs:
           - php: 8.1
             laravel: 11.*
 
-    continue-on-error: ${{ matrix.laravel == '9.*' && matrix.stability == 'prefer-lowest' }}
-
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,18 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.2 ]
-        laravel: [ 9.*, 10.* ]
+        php: [ 8.1, 8.2, 8.3 ]
+        laravel: [ 9.*, 10.*, 11.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 9.*
             testbench: ^7.0
           - laravel: 10.*
             testbench: ^8.0
+          - laravel: 11.*
+            testbench: ^8.0
+
+    continue-on-error: ${{ matrix.laravel == '9.*' && matrix.stability == 'prefer-lowest' }}
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require" : {
         "php" : "^8.0",
-        "illuminate/contracts" : "^9.0|^10.0",
+        "illuminate/contracts" : "^9.0|^10.0|^11.0",
         "ralphjsmit/laravel-helpers" : "^1.5",
         "spatie/laravel-package-tools" : "^1.9.2"
     },
     "require-dev" : {
         "nesbot/carbon" : "^2.66",
-        "nunomaduro/collision" : "^5.10|^6.0",
+        "nunomaduro/collision" : "^5.10|^6.0|^7.0|^8.0",
         "orchestra/testbench" : "^7.0|^8.0",
         "pestphp/pest" : "^1.21",
         "pestphp/pest-plugin-laravel" : "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         "nesbot/carbon" : "^2.66|^3.0",
         "nunomaduro/collision" : "^5.10|^6.0|^7.0|^8.0",
         "orchestra/testbench" : "^7.0|^8.0",
-        "pestphp/pest" : "^1.21",
-        "pestphp/pest-plugin-laravel" : "^1.1",
+        "pestphp/pest" : "^1.21|^2.0",
+        "pestphp/pest-plugin-laravel" : "^1.1|^2.0",
         "phpunit/phpunit" : "^9.5|^10.5",
         "spatie/laravel-ray" : "^1.26",
-        "spatie/pest-plugin-test-time" : "^1.0"
+        "spatie/pest-plugin-test-time" : "^1.0|^2.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "spatie/laravel-package-tools" : "^1.9.2"
     },
     "require-dev" : {
-        "nesbot/carbon" : "^2.66",
+        "nesbot/carbon" : "^2.66|^3.0",
         "nunomaduro/collision" : "^5.10|^6.0|^7.0|^8.0",
         "orchestra/testbench" : "^7.0|^8.0",
         "pestphp/pest" : "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,16 @@
             "role" : "Developer"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/laravel-shift/laravel-helpers.git"
+        }
+    ],
     "require" : {
         "php" : "^8.0",
         "illuminate/contracts" : "^9.0|^10.0|^11.0",
-        "ralphjsmit/laravel-helpers" : "^1.5",
+        "ralphjsmit/laravel-helpers" : "^1.5|dev-l11-compatibility",
         "spatie/laravel-package-tools" : "^1.9.2"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,11 @@
             "role" : "Developer"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/laravel-shift/laravel-helpers.git"
-        }
-    ],
     "require" : {
-        "php" : "^8.0",
-        "illuminate/contracts" : "^9.0|^10.0|^11.0",
-        "ralphjsmit/laravel-helpers" : "^1.5|dev-l11-compatibility",
-        "spatie/laravel-package-tools" : "^1.9.2"
+        "php": "^8.0",
+        "illuminate/contracts": "^11.0",
+        "ralphjsmit/laravel-helpers": "^1.9",
+        "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev" : {
         "nesbot/carbon" : "^2.66|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require" : {
         "php": "^8.0",
-        "illuminate/contracts": "^11.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
         "ralphjsmit/laravel-helpers": "^1.9",
         "spatie/laravel-package-tools": "^1.9.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev" : {
         "nesbot/carbon" : "^2.66|^3.0",
         "nunomaduro/collision" : "^5.10|^6.0|^7.0|^8.0",
-        "orchestra/testbench" : "^7.0|^8.0",
+        "orchestra/testbench" : "^7.0|^8.0|^9.0",
         "pestphp/pest" : "^1.21|^2.0",
         "pestphp/pest-plugin-laravel" : "^1.1|^2.0",
         "phpunit/phpunit" : "^9.5|^10.5",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "orchestra/testbench" : "^7.0|^8.0",
         "pestphp/pest" : "^1.21",
         "pestphp/pest-plugin-laravel" : "^1.1",
-        "phpunit/phpunit" : "^9.5",
+        "phpunit/phpunit" : "^9.5|^10.5",
         "spatie/laravel-ray" : "^1.26",
         "spatie/pest-plugin-test-time" : "^1.0"
     },

--- a/tests/Feature/Tags/CanonicalTagTest.php
+++ b/tests/Feature/Tags/CanonicalTagTest.php
@@ -71,4 +71,4 @@ it('will not break if no canonical_url column exists in seo table', function () 
 
     get(route('seo.test-page', ['page' => $page]))
         ->assertOk();
-});
+})->skip(version_compare(app()->version(), '10', 'lt'));

--- a/tests/Feature/Tags/CanonicalTagTest.php
+++ b/tests/Feature/Tags/CanonicalTagTest.php
@@ -71,4 +71,4 @@ it('will not break if no canonical_url column exists in seo table', function () 
 
     get(route('seo.test-page', ['page' => $page]))
         ->assertOk();
-})->skip(version_compare(app()->version(), '10', 'lt'));
+})->skip(version_compare(Illuminate\Foundation\Application::VERSION, '10', 'lt'));


### PR DESCRIPTION
Hey @ralphjsmit, Don't know if this is useful for you, maybe it helps.


# Blockers

- [x] https://github.com/orchestral/testbench/issues/397
- [ ] https://github.com/ralphjsmit/laravel-helpers/pull/16

## Suggested fix for Failing Tests in Laravel 9

I think this is a sane way to skip this test for Laravel 9 so we dont need to install doctrine/dbal only to fix this particular test.
 [tests/Feature/Tags/CanonicalTagTest.php](https://github.com/ralphjsmit/laravel-seo/pull/67/files#diff-112fa68f85eddc64b66ab7c2ba3ad2ec4c1c542f51e5b4a6ea56578e32f87117)

I'm regularly getting ratelimited on the CI tests, maybe the test matrix is a bit of an overkill.