### PR TITLE
Add support for FAQPage schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package generates **valid and useful meta tags straight out-of-the-box**, w
 2. Meta tags (author, description, image, robots, etc.)
 3. OpenGraph Tags (Facebook, LinkedIn, etc.)
 4. Twitter Tags
-5. Structured data (Article and Breadcrumbs)
+5. Structured data (Article, Breadcrumbs and FAQPage)
 6. Favicon
 7. Robots tag
 

--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ use RalphJSmit\Laravel\SEO\SchemaCollection;
 SchemaCollection::initialize()
     ->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
         return $faqPage
-           ->addQuestion( name: "Can this package add FaqPage to the schema?", acceptedAnswer: "Yes!" )
-           ->addQuestion( name: "Does it support multiple questions?", acceptedAnswer: "Of course." );
+           ->addQuestion(name: "Can this package add FaqPage to the schema?", acceptedAnswer: "Yes!")
+           ->addQuestion(name: "Does it support multiple questions?", acceptedAnswer: "Of course.");
    });
 ```
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ This package can also **generate structured data** for you (also called schema m
 
 1. `Article`
 2. `BreadcrumbList`
+3. `FAQPage`
 
 After generating the structured data it is always a good idea to [test your website with Google's rich result validator](https://search.google.com/test/rich-results).
 
@@ -390,6 +391,25 @@ This code will generate `BreadcrumbList` JSON-LD structured data with the follow
 2. Category
 3. [Current page]
 4. Subarticle
+
+### FAQPage schema markup
+
+You can also add `FAQPage` schema markup by using the `->addFaqPage()` function on the `SchemaCollection`:
+
+```php
+use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
+use RalphJSmit\Laravel\SEO\SchemaCollection;
+
+SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
+    return $faqPage->addQuestion(
+        name: "Can this package add FaqPage to the schema?",
+        acceptedAnswer: "Yes!"
+    )->addQuestion(
+        name: "Does it support multiple questions?",
+        acceptedAnswer: "Of course."
+    );
+});
+```
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You can completely customize the schema markup by using the `->markup()` method 
 ```php
 use Illuminate\Support\Collection;
 
-SchemaCollection::initialize()->addArticle(function(ArticleSchema $article): ArticleSchema {
+SchemaCollection::initialize()->addArticle(function (ArticleSchema $article): ArticleSchema {
     return $article->markup(function(Collection $markup): Collection {
         return $markup->put('alternativeHeadline', $this->tagline);
     });
@@ -372,7 +372,7 @@ You can also add `BreadcrumbList` schema markup by using the `->addBreadcrumbs()
 
 ```php
 SchemaCollection::initialize()
-   ->addBreadcrumbs(function(BreadcrumbListSchema $breadcrumbs): BreadcrumbListSchema {
+   ->addBreadcrumbs(function (BreadcrumbListSchema $breadcrumbs): BreadcrumbListSchema {
         return $breadcrumbs
             ->prependBreadcrumbs([
                'Homepage' => 'https://example.com',

--- a/README.md
+++ b/README.md
@@ -371,18 +371,20 @@ At this point, I'm just unable to fluently support every possible version of the
 You can also add `BreadcrumbList` schema markup by using the `->addBreadcrumbs()` function on the `SchemaCollection`:
 
 ```php
-SchemaCollection::initialize()->addBreadcrumbs(
-    function(BreadcrumbListSchema $breadcrumbs): BreadcrumbListSchema {
-        return $breadcrumbs->prependBreadcrumbs([
-            'Homepage' => 'https://example.com',
-            'Category' => 'https://example.com/test',
-        ])->appendBreadcrumbs([
-            'Subarticle' => 'https://example.com/test/article/2',
-        ])->markup(function(Collection $markup): Collection {
-            // ...
-        });
-    }
-);
+SchemaCollection::initialize()
+   ->addBreadcrumbs(function(BreadcrumbListSchema $breadcrumbs): BreadcrumbListSchema {
+        return $breadcrumbs
+            ->prependBreadcrumbs([
+               'Homepage' => 'https://example.com',
+               'Category' => 'https://example.com/test',
+            ])
+            ->appendBreadcrumbs([
+                'Subarticle' => 'https://example.com/test/article/2',
+            ])
+            ->markup(function(Collection $markup): Collection {
+               // ...
+            });
+    });
 ```
 
 This code will generate `BreadcrumbList` JSON-LD structured data with the following four pages:
@@ -400,15 +402,12 @@ You can also add `FAQPage` schema markup by using the `->addFaqPage()` function 
 use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
 use RalphJSmit\Laravel\SEO\SchemaCollection;
 
-SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
-    return $faqPage->addQuestion(
-        name: "Can this package add FaqPage to the schema?",
-        acceptedAnswer: "Yes!"
-    )->addQuestion(
-        name: "Does it support multiple questions?",
-        acceptedAnswer: "Of course."
-    );
-});
+SchemaCollection::initialize()
+    ->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
+        return $faqPage
+           ->addQuestion( name: "Can this package add FaqPage to the schema?", acceptedAnswer: "Yes!" )
+           ->addQuestion( name: "Does it support multiple questions?", acceptedAnswer: "Of course." );
+   });
 ```
 
 ## Advanced usage

--- a/src/Schema/FaqPageSchema.php
+++ b/src/Schema/FaqPageSchema.php
@@ -19,12 +19,12 @@ class FaqPageSchema extends Schema
         string $acceptedAnswer
     ): static {
         $this->questions[] = [
-            "@type" => "Question",
-            "name" => $name,
-            "acceptedAnswer" => [
-                "@type" => "Answer",
-                "text" => $acceptedAnswer
-            ]
+            '@type' => 'Question',
+            'name' => $name,
+            'acceptedAnswer' => [
+                '@type' => 'Answer',
+                'text' => $acceptedAnswer,
+            ],
         ];
 
         return $this;
@@ -32,7 +32,7 @@ class FaqPageSchema extends Schema
 
     public function initializeMarkup(SEOData $SEOData, array $markupBuilders): void
     {
-        // 
+        //
     }
 
     public function generateInner(): HtmlString

--- a/src/Schema/FaqPageSchema.php
+++ b/src/Schema/FaqPageSchema.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace RalphJSmit\Laravel\SEO\Schema;
+
+use Illuminate\Support\HtmlString;
+use RalphJSmit\Laravel\SEO\Support\SEOData;
+
+/**
+ * @see https://developers.google.com/search/docs/appearance/structured-data/faqpage
+ */
+class FaqPageSchema extends Schema
+{
+    public string $type = 'FAQPage';
+
+    public array $questions = [];
+
+    public function addQuestion(
+        string $name,
+        string $acceptedAnswer
+    ): static {
+        $this->questions[] = [
+            "@type" => "Question",
+            "name" => $name,
+            "acceptedAnswer" => [
+                "@type" => "Answer",
+                "text" => $acceptedAnswer
+            ]
+        ];
+
+        return $this;
+    }
+
+    public function initializeMarkup(SEOData $SEOData, array $markupBuilders): void
+    {
+        // 
+    }
+
+    public function generateInner(): HtmlString
+    {
+        $inner = collect([
+            '@context' => 'https://schema.org',
+            '@type' => $this->type,
+            'mainEntity' => $this->questions,
+        ])
+            ->pipeThrough($this->markupTransformers)
+            ->toJson();
+
+        return new HtmlString($inner);
+    }
+}

--- a/src/SchemaCollection.php
+++ b/src/SchemaCollection.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Collection;
 use RalphJSmit\Laravel\SEO\Schema\ArticleSchema;
 use RalphJSmit\Laravel\SEO\Schema\BreadcrumbListSchema;
+use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
 use RalphJSmit\Laravel\SEO\Schema\Schema;
 
 class SchemaCollection extends Collection
@@ -13,6 +14,7 @@ class SchemaCollection extends Collection
     protected array $dictionary = [
         'article' => ArticleSchema::class,
         'breadcrumbs' => BreadcrumbListSchema::class,
+        'faqPage' => FaqPageSchema::class,
     ];
 
     public array $markup = [];
@@ -27,6 +29,13 @@ class SchemaCollection extends Collection
     public function addBreadcrumbs(?Closure $builder = null): static
     {
         $this->markup[$this->dictionary['breadcrumbs']][] = $builder ?: fn (Schema $schema): Schema => $schema;
+
+        return $this;
+    }
+
+    public function addFaqPage(?Closure $builder = null): static
+    {
+        $this->markup[$this->dictionary['faqPage']][] = $builder ?: fn (Schema $schema): Schema => $schema;
 
         return $this;
     }

--- a/tests/Feature/JSON-LD/FaqPageTest.php
+++ b/tests/Feature/JSON-LD/FaqPageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
+use RalphJSmit\Laravel\SEO\SchemaCollection;
+use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
+
+use function Pest\Laravel\get;
+
+it('does not render by default the JSON-LD Schema markup: FaqPageTest', function () {
+    get(route('seo.test-plain'))
+        ->assertDontSee('"application/ld+json"')
+        ->assertDontSee('"@type": "FAQPage"');
+});
+
+it('can correctly render the JSON-LD Schema markup: FaqPageTest', function () {
+    config()->set('seo.title.suffix', ' | Laravel SEO');
+
+    $page = Page::create([]);
+
+    $page::$overrides = [
+        'title' => 'Test FAQ',
+        'enableTitleSuffix' => true,
+        'url' => 'https://example.com/test/faq',
+        'schema' => SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $breadcrumbList): FaqPageSchema {
+            return $breadcrumbList->addQuestion(
+                name: "Can this package add FaqPage to the schema?",
+                acceptedAnswer: "Yes!"
+            )->addQuestion(
+                name: "Does it support multiple questions?",
+                acceptedAnswer: "Of course."
+            );
+        }),
+    ];
+
+    get(route('seo.test-page', ['page' => $page]))
+        ->assertSee('"application/ld+json"', false)
+        ->assertSee(
+            '<script type="application/ld+json">' .
+                json_encode([
+                    '@context' => 'https://schema.org',
+                    '@type' => 'FAQPage',
+                    'mainEntity' => [
+                        [
+                            '@type' => 'Question',
+                            'name' => 'Can this package add FaqPage to the schema?',
+                            'acceptedAnswer' => [
+                                '@type' => 'Answer',
+                                'text' => 'Yes!',
+                            ],
+                        ],
+                        [
+                            '@type' => 'Question',
+                            'name' => 'Does it support multiple questions?',
+                            'acceptedAnswer' => [
+                                '@type' => 'Answer',
+                                'text' => 'Of course.',
+                            ],
+                        ],
+                    ],
+                ]) . '</script>',
+            false
+        );
+});

--- a/tests/Feature/JSON-LD/FaqPageTest.php
+++ b/tests/Feature/JSON-LD/FaqPageTest.php
@@ -22,13 +22,9 @@ it('can correctly render the JSON-LD Schema markup: FaqPageTest', function () {
         'enableTitleSuffix' => true,
         'url' => 'https://example.com/test/faq',
         'schema' => SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
-            return $faqPage->addQuestion(
-                name: 'Can this package add FaqPage to the schema?',
-                acceptedAnswer: 'Yes!'
-            )->addQuestion(
-                name: 'Does it support multiple questions?',
-                acceptedAnswer: 'Of course.'
-            );
+            return $faqPage
+                ->addQuestion(name: 'Can this package add FaqPage to the schema?', acceptedAnswer: 'Yes!')
+                ->addQuestion(name: 'Does it support multiple questions?', acceptedAnswer: 'Of course.');
         }),
     ];
 

--- a/tests/Feature/JSON-LD/FaqPageTest.php
+++ b/tests/Feature/JSON-LD/FaqPageTest.php
@@ -21,8 +21,8 @@ it('can correctly render the JSON-LD Schema markup: FaqPageTest', function () {
         'title' => 'Test FAQ',
         'enableTitleSuffix' => true,
         'url' => 'https://example.com/test/faq',
-        'schema' => SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $breadcrumbList): FaqPageSchema {
-            return $breadcrumbList->addQuestion(
+        'schema' => SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
+            return $faqPage->addQuestion(
                 name: "Can this package add FaqPage to the schema?",
                 acceptedAnswer: "Yes!"
             )->addQuestion(

--- a/tests/Feature/JSON-LD/FaqPageTest.php
+++ b/tests/Feature/JSON-LD/FaqPageTest.php
@@ -23,11 +23,11 @@ it('can correctly render the JSON-LD Schema markup: FaqPageTest', function () {
         'url' => 'https://example.com/test/faq',
         'schema' => SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
             return $faqPage->addQuestion(
-                name: "Can this package add FaqPage to the schema?",
-                acceptedAnswer: "Yes!"
+                name: 'Can this package add FaqPage to the schema?',
+                acceptedAnswer: 'Yes!'
             )->addQuestion(
-                name: "Does it support multiple questions?",
-                acceptedAnswer: "Of course."
+                name: 'Does it support multiple questions?',
+                acceptedAnswer: 'Of course.'
             );
         }),
     ];


### PR DESCRIPTION
Hi,

This PR adds support for the FAQPage schema, as documented here https://developers.google.com/search/docs/appearance/structured-data/faqpage.

```php
use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
use RalphJSmit\Laravel\SEO\SchemaCollection;

SchemaCollection::initialize()->addFaqPage(function (FaqPageSchema $faqPage): FaqPageSchema {
    return $faqPage->addQuestion(
        name: "Can this package add FaqPage to the schema?",
        acceptedAnswer: "Yes!"
    )->addQuestion(
        name: "Does it support multiple questions?",
        acceptedAnswer: "Of course."
    );
});
```

It includes tests and documentation ;)

