### PR TITLE
Add support for Alternate links `<link rel="alternate"  ... />`

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ public function getDynamicSEOData(): SEOData
         title: $this->title,
         description: $this->excerpt,
         author: $this->author->fullName,
+        alternates: [
+            new AlternateTag(
+                hreflang: 'en',
+                href: "https://example.com/en",
+            ),
+            new AlternateTag(
+                hreflang: 'fr',
+                href: "https://example.com/fr",
+            ),
+        ],
     );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This package generates **valid and useful meta tags straight out-of-the-box**, w
 5. Structured data (Article and Breadcrumbs)
 6. Favicon
 7. Robots tag
+8. Alternates links tag
 
 If you're familiar with Spatie's media-library package, this package works in almost the same way, but then only for SEO. I'm sure it will be very helpful for you, as it's usually best for a website to have attention for SEO right from the beginning.
 
@@ -273,6 +274,7 @@ You are allowed to only override the properties you want and omit the other prop
 12. `schema` (this should be a SchemaCollection instance, where you can configure the JSON-LD structured data schema tags)
 13. `locale` (this should be the locale of the page. By default this is derived from `app()->getLocale()` and it looks like `en` or `nl`.)
 14. `robots` (should be a string with the content value of the robots meta tag, like `nofollow,noindex`). You can also use the `$SEOData->markAsNoIndex()` to prevent a page from being indexed.
+15. `alternates` (should be an array of `AlternateTag`). Will render `<link rel="alternate" ... />` tags.
 
 Finally, you should update your Blade file, so that it can receive your model when generating the tags:
 

--- a/src/Models/SEO.php
+++ b/src/Models/SEO.php
@@ -48,6 +48,7 @@ class SEO extends Model
             robots: $overrides->robots ?? $this->robots,
             canonical_url: $overrides->canonical_url ?? $this->canonical_url,
             openGraphTitle: $overrides->openGraphTitle ?? null,
+            alternates: $overrides->alternates ?? null,
         );
     }
 }

--- a/src/Support/AlternateTag.php
+++ b/src/Support/AlternateTag.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RalphJSmit\Laravel\SEO\Support;
+
+class AlternateTag extends LinkTag
+{
+    public string $rel = "alternate";
+
+    public function __construct(
+        public string $hreflang,
+        public string $href,
+    ) {
+    }
+}

--- a/src/Support/AlternateTag.php
+++ b/src/Support/AlternateTag.php
@@ -4,11 +4,10 @@ namespace RalphJSmit\Laravel\SEO\Support;
 
 class AlternateTag extends LinkTag
 {
-    public string $rel = "alternate";
-
     public function __construct(
         public string $hreflang,
-        public string $href,
+        string $href,
     ) {
+		parent::__construct('alternate', $href);
     }
 }

--- a/src/Support/AlternateTag.php
+++ b/src/Support/AlternateTag.php
@@ -8,6 +8,6 @@ class AlternateTag extends LinkTag
         public string $hreflang,
         string $href,
     ) {
-		parent::__construct('alternate', $href);
+        parent::__construct('alternate', $href);
     }
 }

--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -11,7 +11,7 @@ class SEOData
     use Pipeable;
 
     /**
-     * @param null|array<array-key, AlternateTag> $alternates
+     * @param  null|array<array-key, AlternateTag>  $alternates
      */
     public function __construct(
         public ?string $title = null,

--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -11,7 +11,7 @@ class SEOData
     use Pipeable;
 
     /**
-     * @param null|(AlternateTag[]) $alternates
+     * @param null|array<array-key, AlternateTag> $alternates
      */
     public function __construct(
         public ?string $title = null,

--- a/src/Support/SEOData.php
+++ b/src/Support/SEOData.php
@@ -10,6 +10,9 @@ class SEOData
 {
     use Pipeable;
 
+    /**
+     * @param null|(AlternateTag[]) $alternates
+     */
     public function __construct(
         public ?string $title = null,
         public ?string $description = null,
@@ -32,6 +35,7 @@ class SEOData
         public ?string $robots = null,
         public ?string $canonical_url = null,
         public ?string $openGraphTitle = null,
+        public ?array $alternates = null,
     ) {
         if ($this->locale === null) {
             $this->locale = app()->getLocale();

--- a/src/TagCollection.php
+++ b/src/TagCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Collection;
 use RalphJSmit\Laravel\SEO\Support\SchemaTagCollection;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
+use RalphJSmit\Laravel\SEO\Tags\AlternateTags;
 use RalphJSmit\Laravel\SEO\Tags\AuthorTag;
 use RalphJSmit\Laravel\SEO\Tags\CanonicalTag;
 use RalphJSmit\Laravel\SEO\Tags\DescriptionTag;
@@ -35,6 +36,7 @@ class TagCollection extends Collection
             OpenGraphTags::initialize($SEOData),
             TwitterCardTags::initialize($SEOData),
             SchemaTagCollection::initialize($SEOData, $SEOData->schema),
+            AlternateTags::initialize($SEOData),
         ])->reject(fn (?Renderable $item): bool => $item === null);
 
         foreach ($tags as $tag) {

--- a/src/Tags/AlternateTags.php
+++ b/src/Tags/AlternateTags.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace RalphJSmit\Laravel\SEO\Tags;
+
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Collection;
+use RalphJSmit\Laravel\SEO\Support\RenderableCollection;
+use RalphJSmit\Laravel\SEO\Support\SEOData;
+
+class AlternateTags extends Collection implements Renderable
+{
+    use RenderableCollection;
+
+    public static function initialize(SEOData $SEOData): ?static
+    {
+        if (empty($SEOData->alternates)) {
+            return null;
+        }
+
+        return new static($SEOData->alternates);
+    }
+}

--- a/tests/Feature/Tags/AlternateTagTest.php
+++ b/tests/Feature/Tags/AlternateTagTest.php
@@ -17,11 +17,11 @@ it('will display the alternates links if the associated SEO model has alternates
         'alternates' => [
             new AlternateTag(
                 hreflang: 'en',
-                href: "https://example.com/en",
+                href: 'https://example.com/en',
             ),
             new AlternateTag(
                 hreflang: 'fr',
-                href: "https://example.com/fr",
+                href: 'https://example.com/fr',
             ),
         ],
     ];

--- a/tests/Feature/Tags/AlternateTagTest.php
+++ b/tests/Feature/Tags/AlternateTagTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use RalphJSmit\Laravel\SEO\Support\AlternateTag;
+use RalphJSmit\Laravel\SEO\Tests\Fixtures\Page;
+
+use function Pest\Laravel\get;
+
+it('will not display the aternates tags if there isn\'t any alternate', function () {
+    get(route('seo.test-plain'))
+        ->assertDontSee('alternate');
+});
+
+it('will display the alternates links if the associated SEO model has alternates links', function () {
+    $page = Page::create();
+
+    $page::$overrides = [
+        'alternates' => [
+            new AlternateTag(
+                hreflang: 'en',
+                href: "https://example.com/en",
+            ),
+            new AlternateTag(
+                hreflang: 'fr',
+                href: "https://example.com/fr",
+            ),
+        ],
+    ];
+
+    get(route('seo.test-page', ['page' => $page]))
+        ->assertSee('<link rel="alternate" href="https://example.com/en" hreflang="en">', false);
+});


### PR DESCRIPTION
Hi,

This PR adds support for alternate links:

```php
new SEOData(
  alternates: [
    new AlternateTag(
      hreflang: 'en',
      href: "https://example.com/en",
    ),
    new AlternateTag(
      hreflang: 'fr',
      href: "https://example.com/fr",
    ),
  ],
)
```

```HTML
<link rel="alternate" hreflang="en" href="https://example.com/en" />
<link rel="alternate" hreflang="fr" href="https://example.com/fr" />
```

It is super useful for multilingual apps or blog.

The PR includes tests and a small documentation update.