### PR TITLE
feat: Inertia V3 support

### DIFF
--- a/src/Tags/TitleTag.php
+++ b/src/Tags/TitleTag.php
@@ -18,8 +18,7 @@ class TitleTag extends Tag
         $this->inner = trim($inner);
 
         if ($this->isCurrentRouteInertiaRoute()) {
-            $attribute = $this->resolveInertiaHeadAttribute();
-            $this->attributes[$attribute] = true;
+            $this->attributes[$this->getInertiaTitleAttributeName()] = true;
         }
     }
 
@@ -53,7 +52,7 @@ class TitleTag extends Tag
         });
     }
 
-    private function resolveInertiaHeadAttribute(): string
+    private function getInertiaTitleAttributeName(): string
     {
         $version = InstalledVersions::getVersion('inertiajs/inertia-laravel');
 

--- a/src/Tags/TitleTag.php
+++ b/src/Tags/TitleTag.php
@@ -52,7 +52,7 @@ class TitleTag extends Tag
         });
     }
 
-    private function getInertiaTitleAttributeName(): string
+    protected function getInertiaTitleAttributeName(): string
     {
         $version = InstalledVersions::getVersion('inertiajs/inertia-laravel');
 

--- a/src/Tags/TitleTag.php
+++ b/src/Tags/TitleTag.php
@@ -3,6 +3,7 @@
 namespace RalphJSmit\Laravel\SEO\Tags;
 
 use Closure;
+use Composer\InstalledVersions;
 use Illuminate\Support\Facades\Route;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 use RalphJSmit\Laravel\SEO\Support\Tag;
@@ -17,7 +18,8 @@ class TitleTag extends Tag
         $this->inner = trim($inner);
 
         if ($this->isCurrentRouteInertiaRoute()) {
-            $this->attributes['inertia'] = true;
+            $attribute = $this->resolveInertiaHeadAttribute();
+            $this->attributes[$attribute] = true;
         }
     }
 
@@ -49,5 +51,16 @@ class TitleTag extends Tag
 
             return is_subclass_of($middleware, \Inertia\Middleware::class);
         });
+    }
+
+    private function resolveInertiaHeadAttribute(): string
+    {
+        $version = InstalledVersions::getVersion('inertiajs/inertia-laravel');
+
+        if ($version && version_compare($version, '3.0.0', '>=')) {
+            return 'data-inertia';
+        }
+
+        return 'inertia';
     }
 }

--- a/src/Tags/TitleTag.php
+++ b/src/Tags/TitleTag.php
@@ -54,6 +54,11 @@ class TitleTag extends Tag
 
     protected function getInertiaTitleAttributeName(): string
     {
+        if (! InstalledVersions::isInstalled('inertiajs/inertia-laravel')) {
+            // @TODO: Upgrade to `data-inertia` in next major-version of package + tests.
+            return 'inertia';
+        }
+
         $version = InstalledVersions::getVersion('inertiajs/inertia-laravel');
 
         if ($version && version_compare($version, '3.0.0', '>=')) {


### PR DESCRIPTION
Inertia.js v3.0 (released March 26, 2026) renamed the `inertia` attribute on head elements to `data-inertia`. This causes the <title> tag rendered by this package to be ignored on Inertia v3 applications, since Inertia no longer recognises the old attribute.

This PR updates TitleTag to detect the installed version of inertiajs/inertia-laravel at runtime using Composer\InstalledVersions and use the appropriate attribute:

- `data-inertia` for v3.0.0+
- `inertia` for v2.x (backward compatible)

Reference: [https://inertiajs.com/upgrade-guide (Head Element Attributes section)](https://inertiajs.com/docs/v3/getting-started/upgrade-guide#head-element-attributes)

Closes #110.